### PR TITLE
Add support for parsing and formatting date and time in multiple formats

### DIFF
--- a/src/main/java/exceptions/InvalidDateTimeFormatException.java
+++ b/src/main/java/exceptions/InvalidDateTimeFormatException.java
@@ -1,0 +1,12 @@
+package exceptions;
+
+public class InvalidDateTimeFormatException extends JarvisException{
+    public InvalidDateTimeFormatException(String message) {
+        super("     Please enter a correct DateTime Format Example: \n" 
+                    + "     \"Nov 12 2022 1200\"" + "\n"
+                    + "     \"12 Nov 2022 1200\"" + "\n"
+                    + "     \"2022-11-12 1200\"" + "\n"
+                    + "     \"12/11/2022 1200\"" + "\n"
+                    + message);
+    }
+}

--- a/src/main/java/jarvis/Deadline.java
+++ b/src/main/java/jarvis/Deadline.java
@@ -1,16 +1,21 @@
 package jarvis;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 public class Deadline extends Task {
 
-    protected String dueDate;
+    private LocalDateTime dueDate;
 
-    public Deadline(String title, String dueDate, boolean isCompleted) {
+    public Deadline(String title, LocalDateTime dueDate, boolean isCompleted) {
         super(title, isCompleted);
         this.dueDate = dueDate;
     }
     
     @Override
     public String toString() {
-        return "D | " + super.toString() + " | " + dueDate;
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(Ui.DATE_TIME_FORMAT);
+        String formattedDueDate = dueDate.format(formatter);
+        return "D | " + super.toString() + " | " + formattedDueDate;
     }
 }

--- a/src/main/java/jarvis/Event.java
+++ b/src/main/java/jarvis/Event.java
@@ -1,16 +1,24 @@
 package jarvis;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 public class Event extends Task {
 
-    private String dueDate;
+    private LocalDateTime fromDateTime;
+    private LocalDateTime toDateTime;
     
-    public Event(String title, String dueDate, boolean isCompleted) {
+    public Event(String title, LocalDateTime fromDateTime, LocalDateTime toDateTime, boolean isCompleted) {
         super(title, isCompleted);
-        this.dueDate = dueDate;
+        this.fromDateTime = fromDateTime;
+        this.toDateTime = toDateTime;
     }
     
     @Override
     public String toString() {
-        return "E | " + super.toString() + " | " + dueDate;
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(Ui.DATE_TIME_FORMAT);
+        String formattedFromDateTime = fromDateTime.format(formatter);
+        String formattedToDateTime = toDateTime.format(formatter);
+        return "E | " + super.toString() + " | " + formattedFromDateTime + " | " + formattedToDateTime;
     }
 }

--- a/src/main/java/jarvis/Task.java
+++ b/src/main/java/jarvis/Task.java
@@ -1,8 +1,11 @@
 package jarvis;
 
+import java.time.LocalDateTime;
+
 public class Task {
     private String title;
     private boolean isCompleted;
+    private LocalDateTime dueDate;
 
     public Task(String title, boolean isCompleted) {
         this.title = title;
@@ -31,6 +34,14 @@ public class Task {
 
     public void unmarkCompleted() {
         isCompleted = false;
+    }
+
+    public LocalDateTime getDueDate() {
+        return dueDate;
+    }
+
+    public void setDueDate(LocalDateTime dueDate) {
+        this.dueDate = dueDate;
     }
 
     public String toString() {

--- a/src/main/java/jarvis/Ui.java
+++ b/src/main/java/jarvis/Ui.java
@@ -6,18 +6,20 @@ public class Ui {
     /**
      * ASCII Art Generated from http://patorjk.com/software/taag/
      */
-    private static final String logo = 
+    private static final String LOGO = 
     "    ██  █████  ██████  ██    ██ ██ ███████ \n" +
     "    ██ ██   ██ ██   ██ ██    ██ ██ ██      \n" +
     "    ██ ███████ ██████  ██    ██ ██ ███████ \n" +
     "██  ██ ██   ██ ██   ██  ██  ██  ██      ██\n" +
     "█████  ██   ██ ██   ██   ████   ██ ███████ \n";
 
+    public static final String DATE_TIME_FORMAT = "MMM dd yyyy HHmm";
+
     public void printIntro() {
         breakLine();
         System.out.println("    Hi Master! I'm your personal assistant: JARVIS! \n" +
                             "\n" +
-                            logo +
+                            LOGO +
                             "\n" +
                             "    How can I serve you today? \n");
         breakLine();

--- a/src/main/java/jarvis/data/jarvis.txt
+++ b/src/main/java/jarvis/data/jarvis.txt
@@ -1,0 +1,4 @@
+D | 0 | D1 | Nov 12 2022 1200
+T | 0 | Todo 1
+D | 0 | Deadline 1 | Nov 12 2023 1220
+E | 1 | Event 2 | Nov 12 2023 1220 | Nov 13 2023 1250


### PR DESCRIPTION
This commit introduces the ability to parse and format date and time values in various common formats, including:
- "MMM dd yyyy HHmm"
- "dd MMM yyyy HHmm"
- "yyyy-MM-dd HHmm"
- "MM/dd/yyyy HH:mm"

These enhancements make the date and time handling more versatile and adaptable to input and output requirements.

